### PR TITLE
Fix own message read marker setting

### DIFF
--- a/client/chatroomwidget.cpp
+++ b/client/chatroomwidget.cpp
@@ -144,11 +144,9 @@ void ChatRoomWidget::setRoom(QuaternionRoom* room)
         m_chatEdit->setText( m_currentRoom->cachedInput() );
         connect( m_currentRoom, &QMatrixClient::Room::typingChanged, this, &ChatRoomWidget::typingChanged );
         connect( m_currentRoom, &QMatrixClient::Room::topicChanged, this, &ChatRoomWidget::topicChanged );
-        connect( m_currentRoom, &QMatrixClient::Room::lastReadEventChanged, this, &ChatRoomWidget::updateReadMarker );
         m_currentRoom->setShown(true);
         topicChanged();
         typingChanged();
-        updateReadMarker(m_currentConnection->user());
     } else {
         m_topicLabel->clear();
         m_currentlyTyping->clear();
@@ -181,13 +179,6 @@ void ChatRoomWidget::typingChanged()
         typingNames << m_currentRoom->roomMembername(user);
     }
     m_currentlyTyping->setText( QString("<i>Currently typing: %1</i>").arg( typingNames.join(", ") ) );
-}
-
-void ChatRoomWidget::updateReadMarker(QMatrixClient::User* user)
-{
-    if (user == m_currentConnection->user())
-        m_quickView->rootContext()
-            ->setContextProperty("lastReadId", m_currentRoom->lastReadEvent(user));
 }
 
 void ChatRoomWidget::topicChanged()

--- a/client/chatroomwidget.cpp
+++ b/client/chatroomwidget.cpp
@@ -28,6 +28,7 @@
 
 #include <QtQml/QQmlContext>
 #include <QtQml/QQmlEngine>
+#include <QtQuick/QQuickView>
 #include <QtQuick/QQuickItem>
 
 #include "lib/room.h"
@@ -143,9 +144,11 @@ void ChatRoomWidget::setRoom(QuaternionRoom* room)
         m_chatEdit->setText( m_currentRoom->cachedInput() );
         connect( m_currentRoom, &QMatrixClient::Room::typingChanged, this, &ChatRoomWidget::typingChanged );
         connect( m_currentRoom, &QMatrixClient::Room::topicChanged, this, &ChatRoomWidget::topicChanged );
+        connect( m_currentRoom, &QMatrixClient::Room::lastReadEventChanged, this, &ChatRoomWidget::updateReadMarker );
         m_currentRoom->setShown(true);
         topicChanged();
         typingChanged();
+        updateReadMarker(m_currentConnection->user());
     } else {
         m_topicLabel->clear();
         m_currentlyTyping->clear();
@@ -178,6 +181,13 @@ void ChatRoomWidget::typingChanged()
         typingNames << m_currentRoom->roomMembername(user);
     }
     m_currentlyTyping->setText( QString("<i>Currently typing: %1</i>").arg( typingNames.join(", ") ) );
+}
+
+void ChatRoomWidget::updateReadMarker(QMatrixClient::User* user)
+{
+    if (user == m_currentConnection->user())
+        m_quickView->rootContext()
+            ->setContextProperty("lastReadId", m_currentRoom->lastReadEvent(user));
 }
 
 void ChatRoomWidget::topicChanged()

--- a/client/chatroomwidget.h
+++ b/client/chatroomwidget.h
@@ -22,17 +22,17 @@
 
 #include <QtWidgets/QWidget>
 
-#include <QtQuick/QQuickView>
-
 namespace QMatrixClient
 {
     class Room;
     class Connection;
+    class User;
     class Event;
 }
 class MessageEventModel;
 class QuaternionRoom;
 class ImageProvider;
+class QQuickView;
 class QListView;
 class QLineEdit;
 class QLabel;
@@ -58,6 +58,7 @@ class ChatRoomWidget: public QWidget
         void setConnection(QMatrixClient::Connection* connection);
         void topicChanged();
         void typingChanged();
+        void updateReadMarker(QMatrixClient::User* user);
         void getPreviousContent();
 
     private slots:

--- a/client/chatroomwidget.h
+++ b/client/chatroomwidget.h
@@ -58,7 +58,6 @@ class ChatRoomWidget: public QWidget
         void setConnection(QMatrixClient::Connection* connection);
         void topicChanged();
         void typingChanged();
-        void updateReadMarker(QMatrixClient::User* user);
         void getPreviousContent();
 
     private slots:

--- a/client/mainwindow.cpp
+++ b/client/mainwindow.cpp
@@ -29,6 +29,7 @@
 #include <QtWidgets/QStatusBar>
 #include <QtWidgets/QLabel>
 #include <QtGui/QMovie>
+#include <QtGui/QCloseEvent>
 
 #include "quaternionconnection.h"
 #include "quaternionroom.h"

--- a/client/models/messageeventmodel.cpp
+++ b/client/models/messageeventmodel.cpp
@@ -37,6 +37,31 @@
 #include "lib/events/roomtopicevent.h"
 #include "lib/events/unknownevent.h"
 
+enum EventRoles {
+    EventTypeRole = Qt::UserRole + 1,
+    EventIdRole,
+    TimeRole,
+    DateRole,
+    AuthorRole,
+    ContentRole,
+    ContentTypeRole,
+    HighlightRole,
+};
+
+QHash<int, QByteArray> MessageEventModel::roleNames() const
+{
+    QHash<int, QByteArray> roles = QAbstractItemModel::roleNames();
+    roles[EventTypeRole] = "eventType";
+    roles[EventIdRole] = "eventId";
+    roles[TimeRole] = "time";
+    roles[DateRole] = "date";
+    roles[AuthorRole] = "author";
+    roles[ContentRole] = "content";
+    roles[ContentTypeRole] = "contentType";
+    roles[HighlightRole] = "highlight";
+    return roles;
+}
+
 MessageEventModel::MessageEventModel(QObject* parent)
     : QAbstractListModel(parent)
     , m_connection(nullptr)
@@ -295,18 +320,10 @@ QVariant MessageEventModel::data(const QModelIndex& index, int role) const
             return QSettings().value("UI/highlight_color", "orange");
         }
     }
-    return QVariant();
-}
+    if( role == EventIdRole )
+    {
+        return event->id();
+    }
 
-QHash<int, QByteArray> MessageEventModel::roleNames() const
-{
-    QHash<int, QByteArray> roles = QAbstractItemModel::roleNames();
-    roles[EventTypeRole] = "eventType";
-    roles[TimeRole] = "time";
-    roles[DateRole] = "date";
-    roles[AuthorRole] = "author";
-    roles[ContentRole] = "content";
-    roles[ContentTypeRole] = "contentType";
-    roles[HighlightRole] = "highlight";
-    return roles;
+    return QVariant();
 }

--- a/client/models/messageeventmodel.h
+++ b/client/models/messageeventmodel.h
@@ -31,16 +31,6 @@ class MessageEventModel: public QAbstractListModel
 {
         Q_OBJECT
     public:
-        enum EventRoles {
-            EventTypeRole = Qt::UserRole + 1,
-            TimeRole,
-            DateRole,
-            AuthorRole,
-            ContentRole,
-            ContentTypeRole,
-            HighlightRole
-        };
-
         MessageEventModel(QObject* parent = nullptr);
         virtual ~MessageEventModel();
 

--- a/client/models/messageeventmodel.h
+++ b/client/models/messageeventmodel.h
@@ -30,6 +30,7 @@ class Message;
 class MessageEventModel: public QAbstractListModel
 {
         Q_OBJECT
+        Q_PROPERTY(QString lastReadId READ lastReadId NOTIFY lastReadIdChanged STORED false)
     public:
         MessageEventModel(QObject* parent = nullptr);
         virtual ~MessageEventModel();
@@ -42,6 +43,11 @@ class MessageEventModel: public QAbstractListModel
         int rowCount(const QModelIndex& parent = QModelIndex()) const override;
         QVariant data(const QModelIndex& index, int role = Qt::DisplayRole) const override;
         QHash<int, QByteArray> roleNames() const override;
+
+        QString lastReadId() const;
+
+    signals:
+        void lastReadIdChanged();
 
     private:
         QMatrixClient::Connection* m_connection;

--- a/client/qml/chat.qml
+++ b/client/qml/chat.qml
@@ -196,7 +196,7 @@ Rectangle {
                 }
             }
             Rectangle {
-                visible: lastReadId == eventId
+                visible: messageModel.lastReadId === eventId
                 color: message.textColor
                 width: parent.width
                 height: 1

--- a/client/qml/chat.qml
+++ b/client/qml/chat.qml
@@ -104,91 +104,103 @@ Rectangle {
     Component {
         id: messageDelegate
 
-        RowLayout {
-            id: message
+        Rectangle {
             width: parent.width
-            spacing: 3
+            height: childrenRect.height
 
-            property string textColor:
-                    if (highlight) decoration
-                    else if (eventType == "state" || eventType == "other") disabledPalette.text
-                    else defaultPalette.text
+            RowLayout {
+                id: message
+                width: parent.width
+                spacing: 3
 
-            Label {
-                Layout.alignment: Qt.AlignTop
-                id: timelabel
-                text: "<" + time.toLocaleTimeString(Qt.locale(), Locale.ShortFormat) + ">"
-                color: disabledPalette.text
-            }
-            Label {
-                Layout.alignment: Qt.AlignTop | Qt.AlignLeft
-                Layout.preferredWidth: 120
-                elide: Text.ElideRight
-                text: eventType == "state" || eventType == "emote" ? "* " + author :
-                      eventType != "other" ? author : "***"
-                horizontalAlignment: if( ["other", "emote", "state"]
-                                             .indexOf(eventType) >= 0 )
-                                     { Text.AlignRight }
-                color: message.textColor
+                property string textColor:
+                        if (highlight) decoration
+                        else if (eventType == "state" || eventType == "other") disabledPalette.text
+                        else defaultPalette.text
+
+                Label {
+                    Layout.alignment: Qt.AlignTop
+                    id: timelabel
+                    text: "<" + time.toLocaleTimeString(Qt.locale(), Locale.ShortFormat) + ">"
+                    color: disabledPalette.text
+                }
+                Label {
+                    Layout.alignment: Qt.AlignTop | Qt.AlignLeft
+                    Layout.preferredWidth: 120
+                    elide: Text.ElideRight
+                    text: eventType == "state" || eventType == "emote" ? "* " + author :
+                          eventType != "other" ? author : "***"
+                    horizontalAlignment: if( ["other", "emote", "state"]
+                                                 .indexOf(eventType) >= 0 )
+                                         { Text.AlignRight }
+                    color: message.textColor
+                }
+                Rectangle {
+                    color: defaultPalette.base
+                    Layout.fillWidth: true
+                    Layout.minimumHeight: childrenRect.height
+                    Layout.alignment: Qt.AlignTop | Qt.AlignLeft
+
+                    Column {
+                        spacing: 0
+                        width: parent.width
+
+                        TextEdit {
+                            id: contentField
+                            selectByMouse: true; readOnly: true; font: timelabel.font;
+                            textFormat: contentType == "text/html" ? TextEdit.RichText
+                                                                   : TextEdit.PlainText;
+                            text: eventType != "image" ? content : ""
+                            height: eventType != "image" ? implicitHeight : 0
+                            wrapMode: Text.Wrap; width: parent.width
+                            color: message.textColor
+
+                            MouseArea {
+                                anchors.fill: parent
+                                cursorShape: parent.hoveredLink ? Qt.PointingHandCursor : Qt.IBeamCursor
+                                acceptedButtons: Qt.NoButton
+                            }
+                            onLinkActivated: {
+                                Qt.openUrlExternally(link)
+                            }
+                        }
+                        Image {
+                            id: imageField
+                            fillMode: Image.PreserveAspectFit
+                            width: eventType == "image" ? parent.width : 0
+
+                            sourceSize: eventType == "image" ? "500x500" : "0x0"
+                            source: eventType == "image" ? content : ""
+                        }
+                        Loader {
+                            asynchronous: true
+                            visible: status == Loader.Ready
+                            width: parent.width
+                            property string sourceText: toolTip
+
+                            sourceComponent: showSource.checked ? sourceArea : undefined
+                        }
+                    }
+                }
+                ToolButton {
+                    id: showSourceButton
+                    text: "..."
+                    Layout.alignment: Qt.AlignTop
+
+                    action: Action {
+                        id: showSource
+
+                        tooltip: "Show source"
+                        checkable: true
+                    }
+                }
             }
             Rectangle {
-                color: defaultPalette.base
-                Layout.fillWidth: true
-                Layout.minimumHeight: childrenRect.height
-                Layout.alignment: Qt.AlignTop | Qt.AlignLeft
-
-                Column {
-                    spacing: 0
-                    width: parent.width
-
-                    TextEdit {
-                        id: contentField
-                        selectByMouse: true; readOnly: true; font: timelabel.font;
-                        textFormat: contentType == "text/html" ? TextEdit.RichText
-                                                               : TextEdit.PlainText;
-                        text: eventType != "image" ? content : ""
-                        height: eventType != "image" ? implicitHeight : 0
-                        wrapMode: Text.Wrap; width: parent.width
-                        color: message.textColor
-
-                        MouseArea {
-                            anchors.fill: parent
-                            cursorShape: parent.hoveredLink ? Qt.PointingHandCursor : Qt.IBeamCursor
-                            acceptedButtons: Qt.NoButton
-                        }
-                        onLinkActivated: {
-                            Qt.openUrlExternally(link)
-                        }
-                    }
-                    Image {
-                        id: imageField
-                        fillMode: Image.PreserveAspectFit
-                        width: eventType == "image" ? parent.width : 0
-
-                        sourceSize: eventType == "image" ? "500x500" : "0x0"
-                        source: eventType == "image" ? content : ""
-                    }
-                    Loader {
-                        asynchronous: true
-                        visible: status == Loader.Ready
-                        width: parent.width
-                        property string sourceText: toolTip
-
-                        sourceComponent: showSource.checked ? sourceArea : undefined
-                    }
-                }
-            }
-            ToolButton {
-                id: showSourceButton
-                text: "..."
-                Layout.alignment: Qt.AlignTop
-
-                action: Action {
-                    id: showSource
-
-                    tooltip: "Show source"
-                    checkable: true
-                }
+                visible: lastReadId == eventId
+                color: message.textColor
+                width: parent.width
+                height: 1
+                anchors.bottom: message.bottom
             }
         }
     }

--- a/client/quaternionroom.cpp
+++ b/client/quaternionroom.cpp
@@ -87,18 +87,17 @@ void QuaternionRoom::doAddNewMessageEvents(const QMatrixClient::Events& events)
 
     m_messages.reserve(m_messages.size() + events.size());
     bool new_message = false;
+    QMatrixClient::Event* lastOwnMessage = nullptr;
     for (auto e: events)
     {
         m_messages.push_back(makeMessage(e));
         if (e->senderId() == connection()->userId())
-        {
-            if (!new_message)
-                setLastReadEvent(connection()->user(), e->id());
-            continue;
-        }
-        if ( e->type() == QMatrixClient::EventType::RoomMessage )
+            lastOwnMessage = e;
+        else if (e->type() == QMatrixClient::EventType::RoomMessage)
             new_message = true;
     }
+    if (lastOwnMessage)
+        setLastReadEvent(connection()->user(), lastOwnMessage->id());
 
     if( !m_unreadMessages && new_message)
     {

--- a/client/quaternionroom.cpp
+++ b/client/quaternionroom.cpp
@@ -86,20 +86,22 @@ void QuaternionRoom::doAddNewMessageEvents(const QMatrixClient::Events& events)
     Room::doAddNewMessageEvents(events);
 
     m_messages.reserve(m_messages.size() + events.size());
-    bool new_message = false;
-    QMatrixClient::Event* lastOwnMessage = nullptr;
+    QMatrixClient::Event* lastNewMessage = nullptr;
     for (auto e: events)
     {
         m_messages.push_back(makeMessage(e));
-        if (e->senderId() == connection()->userId())
-            lastOwnMessage = e;
-        else if (e->type() == QMatrixClient::EventType::RoomMessage)
-            new_message = true;
+        if (e->type() == QMatrixClient::EventType::RoomMessage)
+            lastNewMessage = e;
     }
-    if (lastOwnMessage)
-        setLastReadEvent(connection()->user(), lastOwnMessage->id());
-
-    if( !m_unreadMessages && new_message)
+    if ( events.last()->senderId() == connection()->userId() )
+    {
+        setLastReadEvent(connection()->user(), events.last()->id());
+    }
+    if ( lastNewMessage && lastNewMessage->senderId() == connection()->userId() )
+    {
+        lastNewMessage = nullptr;
+    }
+    if ( !m_unreadMessages && lastNewMessage )
     {
         m_unreadMessages = true;
         emit unreadMessagesChanged(this);


### PR DESCRIPTION
This should fixed the previously discussed problems.
The problem was, that we would actually set the readmarker backwards on some occasions. On others we didn’t advance it far enough. This should give us the right semantics now.
